### PR TITLE
gluonts 0.13.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  # Skip py>310 because pytorch-lightning 1.9.5 is not available for py311. Remove it with a new release.
-  skip: True  # [py<37 or py>310 or s390x]
+  # skipping py311 for and linux-ppc64le because for now dep pytorch is not supported on such platform
+  skip: True  # [py<37 or (py>310 and (linux and ppc64le)) or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  # Skip py>310 because pytorch-lightning 1.9.5 is not available for py311. Remove it with a new release.
+  skip: True  # [py<37 or py>310 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -37,8 +38,6 @@ requirements:
 test:
   imports:
     - gluonts
-  source_files:
-    - test
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pytorch >=1.9,<3
     - pytorch-lightning >=1.5,<3
     - protobuf
-    - scipy >=1.10,<1.11
+    - scipy >=1.10,<2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gluonts" %}
-{% set version = "0.8.1" %}
+{% set version = "0.13.2" %}
 
 package:
   name: {{ name }}
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f6be7eb67f951c22beb3d259a7c3ec1f17e6acfbdb2d0df9a4871383b2a1231
+  sha256: 5c6a2c963a9e1eeedeb148c24599eddd3fbc79a32e2ec43f9b2df422b125c9c4
 
 build:
-  skip: True      # [py<36]
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -23,32 +22,45 @@ requirements:
     - wheel
   run:
     - python
-    - holidays >=0.9
-    - matplotlib ~=3.0
-    - numpy ~=1.16
-    - pandas ~=1.0
-    - pydantic ~=1.1
-    - tqdm ~=4.23
-    - toolz ~=0.10
-    - typing-extensions ~=3.10.0.0
+    - numpy >=1.16,<2
+    - pandas >=1.0,<3
+    - pydantic >=1.7,<2
+    - tqdm >=4.23,<5
+    - toolz >=0.10,<1
+    - typing-extensions >=4.0,<5  # [py<38]
+    # optional deps
+    - pytorch >=1.9,<3
+    - pytorch-lightning >=1.5,<3
+    - protobuf
+    - scipy >=1.10,<1.11
 
 test:
   imports:
     - gluonts
+  source_files:
+    - test
   requires:
     - pip
+    - pytest
+    - pyarrow
+    - statsmodels
+    - flaky
+    - matplotlib-base
   commands:
     - pip check
+    # Skip `test_dataclass_subtype` because of pydantic version incompatibility https://github.com/awslabs/gluonts/issues/1531
+    # Skip tests (test_estimators.py, test_modules.py, test_mqf2_modules.py) that require cpflows
+    - pytest . -v -k "not test_dataclass_subtype" --ignore=test/torch/model/test_estimators.py --ignore=test/torch/model/test_modules.py --ignore=test/torch/model/test_mqf2_modules.py
 
 about:
-  home: https://ts.gluon.ai/
-  license: Apache 2.0
+  home: https://ts.gluon.ai/stable/
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  dev_url: https://github.com/awslabs/gluon-ts
-  doc_url: https://ts.gluon.ai/api/gluonts/gluonts.html
+  dev_url: https://github.com/awslabs/gluonts
+  doc_url: https://ts.gluon.ai/stable/index.html
   summary: GluonTS is a Python toolkit for probabilistic time series modeling, built around Apache MXNet (incubating).
-  description: GluonTS provides utilities for loading and iterating over time series datasets, state of the art models ready to be trained, and building blocks to define your own models and quickly experiment with different solutions.
+  description: GluonTS is a Python package for probabilistic time series modeling, focusing on deep learning based models, based on PyTorch and MXNet.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - toolz >=0.10,<1
     - typing-extensions >=4.0,<5  # [py<38]
     # optional deps
-    - pytorch
+    - pytorch >=1.9,<3
     - pytorch-lightning >=1.5,<3
     - protobuf
     - scipy >=1.10,<1.11
@@ -41,16 +41,8 @@ test:
     - test
   requires:
     - pip
-    - pytest
-    - pyarrow  # [not s390x]
-    - statsmodels
-    - flaky
-    - matplotlib-base
   commands:
     - pip check
-    # Skip `test_dataclass_subtype` because of pydantic version incompatibility https://github.com/awslabs/gluonts/issues/1531
-    # Skip tests (test_estimators.py, test_modules.py, test_mqf2_modules.py) that require cpflows
-    - pytest . -v -k "not test_dataclass_subtype" --ignore=test/torch/model/test_estimators.py --ignore=test/torch/model/test_modules.py --ignore=test/torch/model/test_mqf2_modules.py
 
 about:
   home: https://ts.gluon.ai/stable/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - toolz >=0.10,<1
     - typing-extensions >=4.0,<5  # [py<38]
     # optional deps
-    - pytorch >=1.9,<3
+    - pytorch
     - pytorch-lightning >=1.5,<3
     - protobuf
     - scipy >=1.10,<1.11
@@ -42,7 +42,7 @@ test:
   requires:
     - pip
     - pytest
-    - pyarrow
+    - pyarrow  # [not s390x]
     - statsmodels
     - flaky
     - matplotlib-base
@@ -56,7 +56,9 @@ about:
   home: https://ts.gluon.ai/stable/
   license: Apache-2.0
   license_family: Apache
-  license_file: LICENSE
+  license_file:
+    - NOTICE
+    - LICENSE
   dev_url: https://github.com/awslabs/gluonts
   doc_url: https://ts.gluon.ai/stable/index.html
   summary: GluonTS is a Python toolkit for probabilistic time series modeling, built around Apache MXNet (incubating).


### PR DESCRIPTION
Changelog: https://github.com/awslabs/gluonts/releases
License:
- https://github.com/awslabs/gluonts/blob/v0.13.2/NOTICE
- https://github.com/awslabs/gluonts/blob/v0.13.2/LICENSE
Requirements:
- https://github.com/awslabs/gluonts/blob/v0.13.2/setup.cfg
- https://github.com/awslabs/gluonts/blob/v0.13.2/requirements/requirements.txt
- https://github.com/awslabs/gluonts/blob/v0.13.2/requirements/requirements-pytorch.txt

Actions:
1. Skip `py>310` because of pytorch-lightning 1.9.5 https://github.com/AnacondaRecipes/pytorch-lightning-feedstock/pull/5#issue-1767064723
2. Add `--no-build-isolation` to `script`
3. Update runtime pinnings, add `scipy`
4. Update home, dev, doc urls
5. Fix `license` name
6. Update `description`

