### PR TITLE
Update to 0.14.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gluonts" %}
-{% set version = "0.13.2" %}
+{% set version = "0.14.3" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5c6a2c963a9e1eeedeb148c24599eddd3fbc79a32e2ec43f9b2df422b125c9c4
+  sha256: 955602c7853fc4b252451360848f58542df830fe89c10d38473c4d2000bd9993
 
 build:
   number: 0
   # skipping py311 for and linux-ppc64le because for now dep pytorch is not supported on such platform
-  skip: True  # [py<37 or (py>310 and (linux and ppc64le)) or s390x]
+  skip: true  # [py<37 or (py>310 and (linux and ppc64le)) or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -25,15 +25,20 @@ requirements:
     - python
     - numpy >=1.16,<2
     - pandas >=1.0,<3
-    - pydantic >=1.7,<2
+    - pydantic >=1.7,<3
     - tqdm >=4.23,<5
     - toolz >=0.10,<1
     - typing-extensions >=4.0,<5  # [py<38]
-    # optional deps
+    # Optional dependencies that are part of the "torch" extra, 
+    # but the gluonts package we have on defaults right now includes 
+    # the "torch" extra by default in the runtime requirements. So we
+    # can't remove that dependency without breaking all our users.
     - pytorch >=1.9,<3
-    - pytorch-lightning >=1.5,<3
-    - protobuf
-    - scipy >=1.10,<2
+    - lightning >=2.0,<2.2
+    # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
+    - pytorch-lightning >=2.0,<2.2
+    - scipy >=1.7.3,<2  # [py<38]
+    - scipy >=1.10,<2   # [py>37]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  # skipping py311 for and linux-ppc64le because for now dep pytorch is not supported on such platform
-  skip: true  # [py<37 or (py>310 and (linux and ppc64le)) or s390x]
+  # skipping py311 for s390x because lightning is not available
+  skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  # skipping py311 for s390x because lightning is not available
+  # skipping s390x because lightning is not available
   skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,8 @@ requirements:
     - lightning >=2.0,<2.2
     # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
     - pytorch-lightning >=2.0,<2.2
-    - scipy >=1.7.3,<2  # [py<38]
-    - scipy >=1.10,<2   # [py>37]
+    - scipy >=1.7.3,<1.8  # [py<38]
+    - scipy >=1.10,<1.11  # [py>37]
 
 test:
   imports:


### PR DESCRIPTION
Upstream: https://github.com/awslabs/gluonts/tree/v0.14.3

https://anaconda.atlassian.net/browse/PKG-3654

Channel: Defaults

Note that it requires `lightning` which is only on `sfe1ed40`. Also note that `lightning` is technically an optional dependency that is part of the `torch` extra, but the `gluonts` package we have on defaults right now includes the `torch` extra by default in the runtime requirements. So we can’t remove that dependency without breaking all our users.

This PR is pending an approval from the customer.

Also note that we can't merge until the requires dependencies are on defaults.