### PR TITLE
gluon-ts 0.15.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/lightning-feedstock/pr3/7498d95

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/lightning-feedstock/pr3/7498d95

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-remove-mqf2-cpflows-tests-in-torch.patch
 
 build:
-  number: 0
+  number: 1
   # skipping s390x because lightning is not available
   skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     # the "torch" extra by default in the runtime requirements. So we
     # can't remove that dependency without breaking all our users.
     - pytorch >=1.9,<3
-    - lightning >=2.0,<2.2
+    # Relax upperbound to match autogluon-timeseries
+    - lightning >=2.0,<2.4
     # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
     # Relax upperbound to match autogluon-timeseries
     - pytorch-lightning >=2.0,<2.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,10 +40,10 @@ requirements:
     # the "torch" extra by default in the runtime requirements. So we
     # can't remove that dependency without breaking all our users.
     - pytorch >=1.9,<3
-    # Relax upperbound to match autogluon-timeseries
+    # Relax upperbound to match autogluon-timeseries 1.1.1
     - lightning >=2.0,<2.4
     # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
-    # Relax upperbound to match autogluon-timeseries
+    # Relax upperbound to match autogluon-timeseries 1.1.1
     - pytorch-lightning >=2.0,<2.4
     - scipy >=1.7.3,<1.8  # [py<38]
     - scipy >=1.10,<2     # [py>37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,10 +40,10 @@ requirements:
     # the "torch" extra by default in the runtime requirements. So we
     # can't remove that dependency without breaking all our users.
     - pytorch >=1.9,<3
-    # Relax upperbound to match autogluon-timeseries 1.1.1
+    # Relax upperbound to match autogluon.timeseries 1.1.1
     - lightning >=2.0,<2.4
     # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
-    # Relax upperbound to match autogluon-timeseries 1.1.1
+    # Relax upperbound to match autogluon.timeseries 1.1.1
     - pytorch-lightning >=2.0,<2.4
     - scipy >=1.7.3,<1.8  # [py<38]
     - scipy >=1.10,<2     # [py>37]


### PR DESCRIPTION
gluon-ts 0.15.1 rebuild

**Destination channel:** Defaults

### Links

- [PKG-6532]
- dev_url:        https://github.com/awslabs/gluonts/tree/v0.15.1

### Explanation of changes:

- relaxed `lightning` upperbound to match `autogluon.timeseries`


[PKG-6532]: https://anaconda.atlassian.net/browse/PKG-6532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ