### PR TITLE
Update to v0.16.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gluonts" %}
-{% set version = "0.15.1" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: af1a12b9f22f8db071f31da518a9c61f1539b0036d857826c88091032bb9a845
+  sha256: 706ae751566f57c8405c604b9d1531652de2237a55f27a004612498d90212918
   patches:
     # remove test cases that rely on cpflows extra
     - patches/0001-remove-mqf2-cpflows-tests-in-torch.patch
 
 build:
-  number: 1
+  number: 0
   # skipping s390x because lightning is not available
   skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
@@ -29,51 +29,67 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.16,<2
+    - numpy >=1.16,<2.2
     - pandas >=1.0,<3
     - pydantic >=1.7,<3
-    - tqdm >=4.23,<5
-    - toolz >=0.10,<1
-    - typing-extensions >=4.0,<5  # [py<38]
+    - tqdm >=4.23,<5.0.0.dev0
+    - toolz >=0.10,<1.0.0.dev0
+    - typing-extensions >=4.0,<5.0.0.dev0  # [py<38]
     # Optional dependencies that are part of the "torch" extra, 
     # but the gluonts package we have on defaults right now includes 
     # the "torch" extra by default in the runtime requirements. So we
     # can't remove that dependency without breaking all our users.
     - pytorch >=1.9,<3
-    # Relax upperbound to match autogluon.timeseries 1.1.1
-    - lightning >=2.0,<2.4
+    # Tighten upperbound to match autogluon.timeseries 1.1.1
+    - lightning >=2.2.2,<2.4
     # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
-    # Relax upperbound to match autogluon.timeseries 1.1.1
-    - pytorch-lightning >=2.0,<2.4
-    - scipy >=1.7.3,<1.8  # [py<38]
-    - scipy >=1.10,<2     # [py>37]
+    # Tighten upperbound to match autogluon.timeseries 1.1.1
+    - pytorch-lightning >=2.2.2,<2.4
+    - scipy >=1.7.3,<1.8.0.dev0  # [py<38]
+    - scipy >=1.10,<2.0.0.dev0   # [py>37]
+  run_constrained:
+    # https://github.com/awslabs/gluonts/blob/v0.16.0/requirements/requirements-extras-prophet.txt
+    - prophet >=1.0,<2.0.0.dev0
+    # https://github.com/awslabs/gluonts/blob/v0.16.0/requirements/requirements-extras-shell.txt
+    - flask >=3.0,<4.0.0.dev0
+    - waitress >=3.0.1,<3.1.0.dev0
 
 test:
   source_files:
-    - test/torch
+    - test
+    - pyproject.toml
   imports:
     - gluonts
   requires:
+    # https://github.com/awslabs/gluonts/blob/v0.16.0/requirements/requirements-test.txt
     - pip
     - pytest
     - pandas >=1.1
     - pytest >7.0
-    - pytest-timeout >2.0, <3.0
-    - pytest-xdist >3.0, <4.0
-    - pytest-rerunfailures >=12.0, <14.0
+    - pytest-timeout >2.0,<3.0
+    - pytest-xdist >3.0,<4.0
+    - pytest-rerunfailures >=13.0,<14.0
     - ujson
     - orjson
     - requests
-    - holidays >=0.9,<1
-    - matplotlib-base >=3.6,<4
+    - holidays >=0.9,<1.0.0.dev0
+    - matplotlib-base >=3.6,<4.0.0.dev0
+    - pyarrow
+    - statsmodels >=0.11,<1.0.0.dev0
   commands:
     - pip check
     ## Torch tests to check pytorch-lightning bounds are OK ##
     # MPS Fallback must be enabled on OSX, see https://github.com/awslabs/gluonts/issues/3020
     - export PYTORCH_ENABLE_MPS_FALLBACK=1  # [osx]
     # Rename torch test directory to avoid confusion with torch module
-    - mv test/torch torch_tests
-    - pytest torch_tests -vv
+    - mv test/torch test/torch_tests
+    # Skip tests that throw errors in the C++ engine of a backwards training pass because they're calling view()
+    # instead of reshape() on a tensor.
+    - pytest ./test -vv -k "not (test_estimator_constant_dataset or test_estimator_with_features)"  # [not win]
+    # Windows has additional trouble running arrow and datawriter tests since multiple threads try to open the same
+    # file at the same time. Windows also gets different results when comparing their implementation of a
+    # NegativeBinomial distribution vs scipy. See https://github.com/awslabs/gluonts/issues/3129
+    - pytest ./test -vv -k "not (test_estimator_constant_dataset or test_estimator_with_features or test_arrow or test_dataset_writer or test_custom_neg_bin_logpdf_matches_scipy_neg_bin_logpdf)"  # [win]
 
 about:
   home: https://ts.gluon.ai/stable/
@@ -85,7 +101,9 @@ about:
   dev_url: https://github.com/awslabs/gluonts
   doc_url: https://ts.gluon.ai/stable/
   summary: GluonTS is a Python toolkit for probabilistic time series modeling, built around Apache MXNet (incubating).
-  description: GluonTS is a Python package for probabilistic time series modeling, focusing on deep learning based models, based on PyTorch and MXNet.
+  description: |
+    GluonTS is a Python package for probabilistic time series modeling, focusing on deep learning based models, based
+    on PyTorch and MXNet.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
gluonts 0.16.0

**Destination channel:** defaults

### Links

- [PKG-7414](https://anaconda.atlassian.net/browse/PKG-7414)
- [Upstream repository](https://github.com/awslabs/gluonts/tree/v0.16.0)
- [Upstream changelog/diff](https://github.com/awslabs/gluonts/compare/v0.15.1...v0.16.0)
- Relevant dependency PRs:
  - AnacondaRecipes/pytest-rerunfailures-feedstock#4

### Explanation of changes:

- Build for python 3.13
- Pin deps with development segment to better capture intentions behind `~=` operator
- Added rest of test suite


[PKG-7414]: https://anaconda.atlassian.net/browse/PKG-7414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ